### PR TITLE
fix: main-only CD and GHCR publish permission alignment

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,13 +2,16 @@ name: CI/CD
 
 on:
   pull_request:
-    branches: [main]
+    branches: ["**"]
   push:
-    branches: [main]
+    branches: ["**"]
 
 permissions:
   contents: write
   packages: write
+
+env:
+  IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/admin
 
 concurrency:
   group: ci-cd-${{ github.ref }}
@@ -56,7 +59,7 @@ jobs:
         run: pnpm -s build
 
   build-and-release:
-    if: github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')
+    if: github.event_name == 'push' && github.ref_name == 'main' && !contains(github.event.head_commit.message, '[skip ci]')
     runs-on: ubuntu-latest
     needs: verify
 
@@ -73,8 +76,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.GHCR_USERNAME || github.actor }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Prepare image tag
         id: vars
@@ -90,7 +93,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ghcr.io/seung-ju/admin:${{ steps.vars.outputs.tag }}
+            ${{ env.IMAGE_REPOSITORY }}:${{ steps.vars.outputs.tag }}
           build-args: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
 

--- a/.github/workflows/failure-handler.yml
+++ b/.github/workflows/failure-handler.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   handle-failure:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/helm/admin/values.yaml
+++ b/helm/admin/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/seung-ju/admin
+  repository: ghcr.io/seung-ju-org/admin
   tag: latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Restrict CD (`build-and-release`) to run only on `main` push.
- Keep CI (`verify`) running for all branches/pushes.
- Fix GHCR publish target to use repository owner namespace so Actions token installation matches package destination.
- Align Helm default image repository with org namespace.
- Limit failure-handler issue generation to `main` failures only.

## Related
- Issue: #4
- Link(s): https://github.com/seung-ju-org/admin/issues/4

## Changes
- [ ] API / Schema
- [ ] UI
- [x] CI/CD
- [x] Infra (Docker/Helm/ArgoCD)
- [ ] Test code only

## Test
- [ ] `pnpm -s tsc --noEmit`
- [ ] `pnpm -s lint`
- [ ] `pnpm -s test`
- [ ] `pnpm -s build`
- [x] Workflow logic and target paths reviewed for branch conditions and GHCR namespace

## Risk / Rollback
- Risk: Low to medium. CI trigger scope is widened to all branches; CD is limited to main push only.
- Rollback plan: Revert this PR.

## Checklist
- [x] No sensitive data included
- [x] Migration impact reviewed
- [x] Backward compatibility checked
- [x] Docs updated (README / runbook)

Closes #4
